### PR TITLE
2 scipion3 mm updated coot outputs

### DIFF
--- a/ccp4/tests/test_protocol_coot_refmac.py
+++ b/ccp4/tests/test_protocol_coot_refmac.py
@@ -417,9 +417,12 @@ coot_real_exit(0)
             self.launchProtocol(protCoot)
         except:
             print("second call to coot ended")
-        self.assertIsNotNone(protCoot.coot_000941_Imol_0000_version_0002.getFileName(),
+
+        PDB_output = eval("protCoot.coot_%06d_Imol_0000_version_0002"
+                              % protCoot.getObjId())
+        self.assertIsNotNone(PDB_output.getFileName(),
                              "There was a problem with the alignment")
-        self.assertTrue(os.path.exists(protCoot.coot_000941_Imol_0000_version_0002.getFileName()))
+        self.assertTrue(os.path.exists(PDB_output.getFileName()))
         self.assertTrue(
             os.path.exists(protCoot.output3DMap_0001.getFileName()))
 
@@ -711,6 +714,7 @@ class TestRefmacRefinement2(TestImportData):
             self.launchProtocol(protCoot)
         except:
             print("first call to coot ended")
+
         self.assertIsNotNone(protCoot.testLabel5.getFileName(),
                              "There was a problem with the alignment")
         self.assertTrue(os.path.exists(protCoot.testLabel5.getFileName()))
@@ -725,9 +729,11 @@ class TestRefmacRefinement2(TestImportData):
             self.launchProtocol(protCoot)
         except:
             print("second call to coot ended")
-        self.assertIsNotNone(protCoot.coot_001183_Imol_0000_version_0002.getFileName(),
+        PDB_output = eval("protCoot.coot_%06d_Imol_0000_version_0002"
+                          % protCoot.getObjId())
+        self.assertIsNotNone(PDB_output.getFileName(),
                              "There was a problem with the alignment")
-        self.assertTrue(os.path.exists(protCoot.coot_001183_Imol_0000_version_0002.getFileName()))
+        self.assertTrue(os.path.exists(PDB_output.getFileName()))
         self.assertTrue(
             os.path.exists(protCoot.output3DMap_0001.getFileName()))
 


### PR DESCRIPTION
This PR fixes two protocols that failed due to the updating of the protocol number. Now it is OK and can be checked with:


Test:

scipion3 tests --run --grep ccp4